### PR TITLE
Allow use when home isn't `/home/git/`

### DIFF
--- a/post-deploy
+++ b/post-deploy
@@ -81,4 +81,4 @@ eval "cat <<< \"$(< $NGINX_CONF)\" >> $HOME/$APP/nginx.conf"
 
 pluginhook nginx-pre-reload $APP
 echo '-----> Reloading nginx...'
-nc -U $HOME/reload-nginx
+sudo /etc/init.d/nginx reload > /dev/null

--- a/post-deploy
+++ b/post-deploy
@@ -3,7 +3,7 @@ set -e
 echo "-----> Deploying nginx..."
 APP="$1"; PORT="$2"
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )" #this directory
-APP_PATH="/home/git/$APP"
+APP_PATH="$DOKKU_ROOT/$APP"
 VHOST_PATH="$APP_PATH/VHOST"
 SSL_DIR="$HOME/$APP/ssl"
 


### PR DESCRIPTION
`$DOKKU_ROOT` instead of hardcoding `/home/git/`
