### PR TITLE
Fix empty NONSSL_VHOSTS issue & create default VHOST if dosen't exist

### DIFF
--- a/post-deploy
+++ b/post-deploy
@@ -16,6 +16,19 @@ VHOST_PATH="$APP_PATH/VHOST"
 WILDCARD_SSL_PATH="$DOKKU_ROOT/tls"
 APP_SSL_PATH="$APP_PATH/tls"
 
+# Create VHOST if it does not exist. Use default dokku nginx-vhost plugin
+# way to determine the host name for this app
+if [[ ! -f "$VHOST_PATH" ]]; then
+  VHOST=$(< "$DOKKU_ROOT/VHOST")
+  SUBDOMAIN=${APP/%\.${VHOST}/}
+  if [[ "$APP" == *.* ]] && [[ "$SUBDOMAIN" == "$APP" ]]; then
+    hostname="${APP/\//-}"
+  else
+    hostname="${APP/\//-}.$VHOST"
+  fi
+  echo "$hostname" > "$VHOST_PATH"
+fi 
+
 # Get list of VHOST domains. This will be overridden below if SSL for some
 # domains are enabled. If VHOST does not exist, set to empty string.
 NONSSL_VHOSTS=`cat $VHOST_PATH 2>&- || echo ''`

--- a/post-deploy
+++ b/post-deploy
@@ -6,7 +6,7 @@ set -a #export all subsequently defined variables for template access
 # NOTE: Template variables must be exported (done with set -a above) and placed
 # in brackets (like ${...}) for the regex to process it.
 shopt -s expand_aliases
-alias process_template="perl -p -i -e 's/\\$\{([^}]+)\}/defined \$ENV{\$1} ? \$ENV{\$1} : \$&/eg'"
+alias process_template="perl -p -e 's/\\$\{([^}]+)\}/defined \$ENV{\$1} ? \$ENV{\$1} : \$&/eg'"
 
 echo "-----> Deploying nginx..."
 APP="$1"; PORT="$2"
@@ -100,16 +100,18 @@ if [[ -e $APP_NGINX_TEMPLATE ]]; then
   NGINX_CONF=$APP_NGINX_TEMPLATE
 fi
 
-# The VHOST file can contain more than one custom domain. We add each as a
-# single line to the server_name parameter of nginx instead of creating
-# separate server_name entries for each.
-echo $NONSSL_VHOSTS | xargs -i \
-  echo "-----> Configuring {}..."
-# Combine all of the VHOST names into one line separated by at least a space.
-# Then trim leading and trailing whitespace (xargs). If VHOST file is blank,
-# xargs reduces any whitespace to a blank string.
-SERVER_NAME=`echo $NONSSL_VHOSTS | tr '\n' ' ' | xargs`
-cat $NGINX_CONF | process_template >> $APP_PATH/nginx.conf
+if [[ ! -z "$NONSSL_VHOSTS" ]]; then
+  # The VHOST file can contain more than one custom domain. We add each as a
+  # single line to the server_name parameter of nginx instead of creating
+  # separate server_name entries for each.
+  echo $NONSSL_VHOSTS | xargs -i \
+    echo "-----> Configuring {}..."
+  # Combine all of the VHOST names into one line separated by at least a space.
+  # Then trim leading and trailing whitespace (xargs). If VHOST file is blank,
+  # xargs reduces any whitespace to a blank string.
+  SERVER_NAME=`echo $NONSSL_VHOSTS | tr '\n' ' ' | xargs`
+  cat $NGINX_CONF | process_template >> $APP_PATH/nginx.conf
+fi
 
 # CRUDE HACK: Since the `URL` file only expects one app url, we take the 
 # first  `$NONSSL_VHOSTS` domain and write it to `URL`.

--- a/post-deploy
+++ b/post-deploy
@@ -130,7 +130,8 @@ fi
 # first  `$NONSSL_VHOSTS` domain and write it to `URL`.
 echo "http://$(echo $NONSSL_VHOSTS | head -n1)" > "$DOKKU_ROOT/$APP/URL"
 
-pluginhook nginx-pre-reload $APP
+echo "-----> Running nginx-pre-reload"
+pluginhook nginx-pre-reload $APP $PORT
 echo '-----> Reloading nginx...'
 sudo /etc/init.d/nginx reload > /dev/null
 


### PR DESCRIPTION
This PR implements a fix for an empty NONSSL_VHOSTS which was generating an empty "" host name entrance in the nginx.conf file.

Additionally the second commit creates the VHOST file (if it does not exist) according to rules used in dokku original nginx-vhost plugin
