### PR TITLE
Add the Subject Alternative Name extension

### DIFF
--- a/post-deploy
+++ b/post-deploy
@@ -62,6 +62,8 @@ if [[ -e "$SSL_PATH/server.crt" ]] && [[ -e "$SSL_PATH/server.key" ]]; then
   # e.g. mydomain.com -> mydomain\.com
   #      *.mydomain.com -> .*\.mydomain\.com
   SSL_HOSTNAME=`openssl x509 -in $SSL_PATH/server.crt -noout -subject | tr '/' '\n' | grep CN= | cut -c4-`
+  SSL_HOSTNAME_ALT=`openssl x509 -in $SSL_PATH/server.crt -noout -text | grep --after-context=1 '509v3 Subject Alternative Name:' | tail -n 1 | sed -e "s/[[:space:]]*DNS://g"  | tr ',' '\n'`
+  SSL_HOSTNAME=`echo "$SSL_HOSTNAME $SSL_HOSTNAME_ALT" | tr ' ', '\n' | sort | uniq`
   SSL_HOSTNAME=`echo "$SSL_HOSTNAME" | sed 's|\.|\\.|g' | sed 's/\*/\.\*/g'`
 
   # Only set up SSL for VHOST domains that the SSL certificate apply to. 


### PR DESCRIPTION
The Subject Alternative Name is a common way of having multiple DNS entries for a single certificate (like base domain and www + base domain).  This change attempts to pull those Alt DNS entries if they exist and merge the two lists together.
